### PR TITLE
Add Arkos dual-mode networking skeleton

### DIFF
--- a/docs/arkos_modular_design.md
+++ b/docs/arkos_modular_design.md
@@ -1,0 +1,18 @@
+# Arkos Dual-Mode Networking
+
+This repository adds an experimental architecture for switching between the default Meshtastic mesh and an Arkos specific mesh implementation.
+
+## Network Modes
+
+- **Meshtastic** – uses the stock routing, message formats and radio settings.
+- **Arkos** – uses `ArkosRouter` and additional modules for Arkos message types.
+
+Runtime mode selection is controlled via `currentNetworkMode` (see `NetworkMode.h`).  Modules and routing are instantiated based on this variable so that a device can switch modes without reflashing.
+
+## Extensible Modules
+
+- `ArkosRouter` derives from `ReliableRouter` and is the place for Arkos specific routing logic.
+- `ArkosMessageModule` registers custom port numbers (`0x80`–`0x81`) for encrypted status reports and sensor alerts.
+- `setupArkosModules()` is invoked when Arkos mode is enabled to construct these modules.
+
+Proprietary extensions can live in `src/arkos` without modifying the existing GPLv3 code.  Linking against the GPL components makes the combined firmware subject to GPLv3, but independent modules that communicate over clean interfaces may remain proprietary.

--- a/src/NetworkMode.cpp
+++ b/src/NetworkMode.cpp
@@ -1,0 +1,7 @@
+#include "NetworkMode.h"
+
+NetworkMode currentNetworkMode = NetworkMode::MESHTASTIC;
+
+void setNetworkMode(NetworkMode mode) {
+    currentNetworkMode = mode;
+}

--- a/src/NetworkMode.h
+++ b/src/NetworkMode.h
@@ -1,0 +1,9 @@
+#pragma once
+
+enum class NetworkMode {
+    MESHTASTIC = 0,
+    ARKOS = 1
+};
+
+extern NetworkMode currentNetworkMode;
+void setNetworkMode(NetworkMode mode);

--- a/src/arkos/ArkosModules.cpp
+++ b/src/arkos/ArkosModules.cpp
@@ -1,0 +1,6 @@
+#include "ArkosModules.h"
+#include "modules/ArkosMessageModule.h"
+
+void setupArkosModules() {
+    new ArkosMessageModule();
+}

--- a/src/arkos/ArkosModules.h
+++ b/src/arkos/ArkosModules.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void setupArkosModules();

--- a/src/arkos/ArkosRouter.cpp
+++ b/src/arkos/ArkosRouter.cpp
@@ -1,0 +1,13 @@
+#include "ArkosRouter.h"
+
+ArkosRouter::ArkosRouter() : ReliableRouter() {}
+
+ErrorCode ArkosRouter::send(meshtastic_MeshPacket *p) {
+    // Placeholder for Arkos-specific routing policies
+    return ReliableRouter::send(p);
+}
+
+bool ArkosRouter::shouldFilterReceived(const meshtastic_MeshPacket *p) {
+    // Custom filtering for Arkos messages could go here
+    return ReliableRouter::shouldFilterReceived(p);
+}

--- a/src/arkos/ArkosRouter.h
+++ b/src/arkos/ArkosRouter.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "mesh/ReliableRouter.h"
+
+class ArkosRouter : public ReliableRouter {
+  public:
+    ArkosRouter();
+    virtual ErrorCode send(meshtastic_MeshPacket *p) override;
+
+  protected:
+    virtual bool shouldFilterReceived(const meshtastic_MeshPacket *p) override;
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,8 @@
 #include "PowerFSM.h"
 #include "PowerMon.h"
 #include "ReliableRouter.h"
+#include "arkos/ArkosRouter.h"
+#include "NetworkMode.h"
 #include "airtime.h"
 #include "buzz.h"
 
@@ -733,14 +735,19 @@ void setup()
     }
 #endif
 
-    // If we're taking on the repeater role, use NextHopRouter and turn off 3V3_S rail because peripherals are not needed
+    // If we're taking on the repeater role, use NextHopRouter and disable peripherals
     if (config.device.role == meshtastic_Config_DeviceConfig_Role_REPEATER) {
         router = new NextHopRouter();
 #ifdef PIN_3V3_EN
         digitalWrite(PIN_3V3_EN, LOW);
 #endif
-    } else
-        router = new ReliableRouter();
+    } else {
+        if (currentNetworkMode == NetworkMode::ARKOS) {
+            router = new ArkosRouter();
+        } else {
+            router = new ReliableRouter();
+        }
+    }
 
     // only play start melody when role is not tracker or sensor
     if (config.power.is_power_saving == true &&

--- a/src/modules/ArkosMessageModule.cpp
+++ b/src/modules/ArkosMessageModule.cpp
@@ -1,0 +1,12 @@
+#include "ArkosMessageModule.h"
+
+ArkosMessageModule::ArkosMessageModule() : MeshModule("ArkosMessage") {}
+
+bool ArkosMessageModule::wantPacket(const meshtastic_MeshPacket *p) {
+    return p->decoded.portnum == ARKOS_STATUS || p->decoded.portnum == ARKOS_SENSOR_ALERT;
+}
+
+ProcessMessage ArkosMessageModule::handleReceived(const meshtastic_MeshPacket &p) {
+    // Placeholder: process Arkos-specific messages
+    return ProcessMessage::CONTINUE;
+}

--- a/src/modules/ArkosMessageModule.h
+++ b/src/modules/ArkosMessageModule.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "mesh/MeshModule.h"
+
+class ArkosMessageModule : public MeshModule {
+  public:
+    enum ArkosPort : uint8_t {
+        ARKOS_STATUS = 0x80,
+        ARKOS_SENSOR_ALERT = 0x81
+    };
+
+    ArkosMessageModule();
+
+    virtual bool wantPacket(const meshtastic_MeshPacket *p) override;
+    virtual ProcessMessage handleReceived(const meshtastic_MeshPacket &p) override;
+};

--- a/src/modules/Modules.cpp
+++ b/src/modules/Modules.cpp
@@ -28,6 +28,8 @@
 #if !MESHTASTIC_EXCLUDE_DETECTIONSENSOR
 #include "modules/DetectionSensorModule.h"
 #endif
+#include "NetworkMode.h"
+#include "arkos/ArkosModules.h"
 #if !MESHTASTIC_EXCLUDE_NEIGHBORINFO
 #include "modules/NeighborInfoModule.h"
 #endif
@@ -272,4 +274,8 @@ void setupModules()
     // NOTE! This module must be added LAST because it likes to check for replies from other modules and avoid sending extra
     // acks
     routingModule = new RoutingModule();
+
+    if (currentNetworkMode == NetworkMode::ARKOS) {
+        setupArkosModules();
+    }
 }


### PR DESCRIPTION
## Summary
- introduce `NetworkMode` to toggle between Meshtastic and Arkos modes
- create `ArkosRouter` and `ArkosMessageModule` skeletons
- load Arkos modules when Arkos mode is active
- select router implementation at runtime
- document architecture and GPLv3 boundaries

## Testing
- `pio` not available so build/tests were not executed

------
https://chatgpt.com/codex/tasks/task_e_685d8b976e388327b35ebd51c8a3bc28