### PR TITLE
Add ArkosMesh router and message handlers

### DIFF
--- a/docs/arkos_modular_design.md
+++ b/docs/arkos_modular_design.md
@@ -1,0 +1,22 @@
+# Arkos Dual-Mode Networking
+
+This repository adds an experimental architecture for switching between the default Meshtastic mesh and an Arkos specific mesh implementation.
+
+## Network Modes
+
+- **Meshtastic** – uses the stock routing, message formats and radio settings.
+- **Arkos** – uses `ArkosRouter` and additional modules for Arkos message types.
+
+Runtime mode selection is controlled via `currentNetworkMode` (see `NetworkMode.h`).  Modules and routing are instantiated based on this variable so that a device can switch modes without reflashing.
+
+### ArkosMesh Options
+
+`ArkosConfig` exposes runtime flags for topology (peer, federated or star), power‑aware operation and low‑probability‑of‑detection mode. These settings can be changed dynamically by proprietary modules or future admin commands.
+
+## Extensible Modules
+
+- `ArkosRouter` derives from `ReliableRouter` and implements low-latency route selection, retries, and silent forwarding of authorized traffic.
+- `ArkosMessageModule` registers custom port numbers (`0x80`–`0x83`) and understands sensor reports, control commands, and binary payloads.
+- `setupArkosModules()` is invoked when Arkos mode is enabled to construct these modules.
+
+Proprietary extensions can live in `src/arkos` without modifying the existing GPLv3 code.  Linking against the GPL components makes the combined firmware subject to GPLv3, but independent modules that communicate over clean interfaces may remain proprietary.

--- a/src/NetworkMode.cpp
+++ b/src/NetworkMode.cpp
@@ -1,0 +1,7 @@
+#include "NetworkMode.h"
+
+NetworkMode currentNetworkMode = NetworkMode::MESHTASTIC;
+
+void setNetworkMode(NetworkMode mode) {
+    currentNetworkMode = mode;
+}

--- a/src/NetworkMode.h
+++ b/src/NetworkMode.h
@@ -1,0 +1,9 @@
+#pragma once
+
+enum class NetworkMode {
+    MESHTASTIC = 0,
+    ARKOS = 1
+};
+
+extern NetworkMode currentNetworkMode;
+void setNetworkMode(NetworkMode mode);

--- a/src/arkos/ArkosConfig.cpp
+++ b/src/arkos/ArkosConfig.cpp
@@ -1,0 +1,31 @@
+#include "ArkosConfig.h"
+#include "FSCommon.h"
+#include "SPILock.h"
+
+ArkosConfig arkosConfig;
+
+struct StoredArkosConfig {
+    uint8_t topology;
+    uint8_t powerAware;
+    uint8_t lowProbDetect;
+};
+
+void loadArkosConfig() {
+#ifdef FSCom
+    concurrency::LockGuard g(spiLock);
+    File f = FSCom.open("/arkos.cfg", FILE_O_READ);
+    if (f) {
+        StoredArkosConfig s{};
+        if (f.readBytes(reinterpret_cast<char *>(&s), sizeof(s)) == sizeof(s)) {
+            arkosConfig.topology = static_cast<ArkosTopology>(s.topology);
+            arkosConfig.powerAware = s.powerAware;
+            arkosConfig.lowProbDetect = s.lowProbDetect;
+        }
+        f.close();
+    }
+#endif
+}
+
+void setArkosTopology(ArkosTopology t) { arkosConfig.topology = t; }
+void enablePowerAware(bool en) { arkosConfig.powerAware = en; }
+void enableLowProbDetect(bool en) { arkosConfig.lowProbDetect = en; }

--- a/src/arkos/ArkosConfig.h
+++ b/src/arkos/ArkosConfig.h
@@ -1,0 +1,21 @@
+#pragma once
+
+// Configuration options for ArkosMesh mode
+
+enum class ArkosTopology {
+    P2P = 0,
+    FEDERATED = 1,
+    STAR = 2
+};
+
+struct ArkosConfig {
+    ArkosTopology topology = ArkosTopology::P2P;
+    bool powerAware = false;
+    bool lowProbDetect = false;
+};
+
+extern ArkosConfig arkosConfig;
+void loadArkosConfig();
+void setArkosTopology(ArkosTopology t);
+void enablePowerAware(bool en);
+void enableLowProbDetect(bool en);

--- a/src/arkos/ArkosModules.cpp
+++ b/src/arkos/ArkosModules.cpp
@@ -1,0 +1,8 @@
+#include "ArkosModules.h"
+#include "modules/ArkosMessageModule.h"
+#include "ArkosConfig.h"
+
+void setupArkosModules() {
+    loadArkosConfig();
+    new ArkosMessageModule();
+}

--- a/src/arkos/ArkosModules.h
+++ b/src/arkos/ArkosModules.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void setupArkosModules();

--- a/src/arkos/ArkosRouter.cpp
+++ b/src/arkos/ArkosRouter.cpp
@@ -1,0 +1,62 @@
+#include "ArkosRouter.h"
+#include "PowerFSM.h"
+#include "PowerStatus.h"
+
+ArkosRouter::ArkosRouter() : ReliableRouter() {}
+
+uint8_t ArkosRouter::selectBestNextHop(NodeNum to) {
+    uint8_t bestHop = NO_NEXT_HOP_PREFERENCE;
+    float bestScore = -1000.0f;
+    uint8_t ourRelay = nodeDB->getLastByteOfNodeNum(getNodeNum());
+
+    meshtastic_NodeInfoLite *dest = nodeDB->getMeshNode(to);
+    if (dest && dest->next_hop && dest->next_hop != ourRelay) {
+        return dest->next_hop;
+    }
+
+    for (size_t i = 0; i < nodeDB->getNumMeshNodes(); ++i) {
+        meshtastic_NodeInfoLite *n = nodeDB->getMeshNodeByIndex(i);
+        if (n->num == 0 || n->next_hop == 0 || n->num == to)
+            continue;
+        float hopScore = n->has_hops_away && n->hops_away ? 1.0f / n->hops_away : 0.0f;
+        float score = hopScore + n->snr;
+        if (score > bestScore) {
+            bestScore = score;
+            bestHop = n->next_hop;
+        }
+    }
+    return bestHop;
+}
+
+ErrorCode ArkosRouter::send(meshtastic_MeshPacket *p) {
+    if (!isBroadcast(p->to)) {
+        p->next_hop = selectBestNextHop(p->to);
+    }
+
+    if (arkosConfig.powerAware && powerStatus && powerStatus->getBatteryChargePercent() >= 0 &&
+        powerStatus->getBatteryChargePercent() < 20 && !powerStatus->getIsCharging()) {
+        delay(200); // conserve power when battery low
+    }
+
+    if (arkosConfig.lowProbDetect) {
+        delay(random(20, 120));
+    }
+
+    ErrorCode err = ReliableRouter::send(p);
+    if (err && p) {
+        LOG_WARN("Arkos send failed %d, retrying", err);
+        delay(50);
+        if (!isBroadcast(p->to)) {
+            p->next_hop = selectBestNextHop(p->to);
+        }
+        err = ReliableRouter::send(p);
+    }
+    return err;
+}
+
+bool ArkosRouter::shouldFilterReceived(const meshtastic_MeshPacket *p) {
+    if (p->which_payload_variant == meshtastic_MeshPacket_encrypted_tag && p->pki_encrypted && !isToUs(p)) {
+        return false; // forward silently
+    }
+    return ReliableRouter::shouldFilterReceived(p);
+}

--- a/src/arkos/ArkosRouter.h
+++ b/src/arkos/ArkosRouter.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "mesh/ReliableRouter.h"
+#include "mesh/NodeDB.h"
+#include "ArkosConfig.h"
+
+class ArkosRouter : public ReliableRouter {
+  public:
+    ArkosRouter();
+    virtual ErrorCode send(meshtastic_MeshPacket *p) override;
+
+  protected:
+    uint8_t selectBestNextHop(NodeNum to);
+
+    virtual bool shouldFilterReceived(const meshtastic_MeshPacket *p) override;
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,8 @@
 #include "PowerFSM.h"
 #include "PowerMon.h"
 #include "ReliableRouter.h"
+#include "arkos/ArkosRouter.h"
+#include "NetworkMode.h"
 #include "airtime.h"
 #include "buzz.h"
 
@@ -733,14 +735,19 @@ void setup()
     }
 #endif
 
-    // If we're taking on the repeater role, use NextHopRouter and turn off 3V3_S rail because peripherals are not needed
+    // If we're taking on the repeater role, use NextHopRouter and disable peripherals
     if (config.device.role == meshtastic_Config_DeviceConfig_Role_REPEATER) {
         router = new NextHopRouter();
 #ifdef PIN_3V3_EN
         digitalWrite(PIN_3V3_EN, LOW);
 #endif
-    } else
-        router = new ReliableRouter();
+    } else {
+        if (currentNetworkMode == NetworkMode::ARKOS) {
+            router = new ArkosRouter();
+        } else {
+            router = new ReliableRouter();
+        }
+    }
 
     // only play start melody when role is not tracker or sensor
     if (config.power.is_power_saving == true &&

--- a/src/modules/ArkosMessageModule.cpp
+++ b/src/modules/ArkosMessageModule.cpp
@@ -1,0 +1,84 @@
+#include "ArkosMessageModule.h"
+#include "PowerFSM.h"
+#include "FSCommon.h"
+#include "SPILock.h"
+#if defined(ARCH_ESP32)
+#include "WiFiOTA.h"
+#endif
+
+ArkosMessageModule::ArkosMessageModule() : MeshModule("ArkosMessage") {
+    encryptedOk = true;
+}
+
+bool ArkosMessageModule::wantPacket(const meshtastic_MeshPacket *p) {
+    return p->decoded.portnum == ARKOS_STATUS || p->decoded.portnum == ARKOS_SENSOR_ALERT ||
+           p->decoded.portnum == ARKOS_CONTROL || p->decoded.portnum == ARKOS_BINARY;
+}
+
+ProcessMessage ArkosMessageModule::handleReceived(const meshtastic_MeshPacket &p) {
+    const pb_bytes_array_t *payload = nullptr;
+    if (p.which_payload_variant == meshtastic_MeshPacket_decoded_tag) {
+        payload = &p.decoded.payload;
+    } else if (p.which_payload_variant == meshtastic_MeshPacket_encrypted_tag) {
+        payload = &p.encrypted;
+    }
+    if (!payload || payload->size < 1)
+        return ProcessMessage::CONTINUE;
+
+    ArkosMsgType type = static_cast<ArkosMsgType>(payload->bytes[0]);
+    const uint8_t *data = &payload->bytes[1];
+    size_t len = payload->size - 1;
+
+    switch (type) {
+        case SENSOR_REPORT:
+            handleSensorReport(data, len);
+            break;
+        case BINARY_PAYLOAD:
+            handleBinaryPayload(data, len);
+            break;
+        case CONTROL_CMD:
+            handleControlCmd(data, len);
+            break;
+        case OTA_TRIGGER:
+#if defined(ARCH_ESP32)
+            WiFiOTA::saveConfig(&config.network);
+            if (WiFiOTA::trySwitchToOTA()) {
+                powerFSM.trigger(EVENT_FIRMWARE_UPDATE);
+            }
+#endif
+            break;
+        default:
+            break;
+    }
+    return ProcessMessage::STOP;
+}
+
+void ArkosMessageModule::handleSensorReport(const uint8_t *data, size_t len) {
+    if (len < 5)
+        return;
+    uint8_t sensorId = data[0];
+    int32_t value;
+    memcpy(&value, &data[1], 4);
+    LOG_INFO("Sensor %u report %d", sensorId, value);
+}
+
+void ArkosMessageModule::handleBinaryPayload(const uint8_t *data, size_t len) {
+    LOG_INFO("Received %u bytes of binary payload", (unsigned)len);
+#ifdef FSCom
+    concurrency::LockGuard g(spiLock);
+    File f = FSCom.open("/arkos_payload.bin", FILE_O_WRITE);
+    if (f) {
+        f.write(data, len);
+        f.flush();
+        f.close();
+        LOG_DEBUG("Binary payload stored");
+    } else {
+        LOG_ERROR("Failed to store binary payload");
+    }
+#endif
+}
+
+void ArkosMessageModule::handleControlCmd(const uint8_t *data, size_t len) {
+    std::string cmd(reinterpret_cast<const char *>(data), len);
+    LOG_INFO("Control command: %s", cmd.c_str());
+}

--- a/src/modules/ArkosMessageModule.h
+++ b/src/modules/ArkosMessageModule.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "mesh/MeshModule.h"
+
+class ArkosMessageModule : public MeshModule {
+  public:
+    enum ArkosPort : uint8_t {
+        ARKOS_STATUS = 0x80,
+        ARKOS_SENSOR_ALERT = 0x81,
+        ARKOS_CONTROL = 0x82,
+        ARKOS_BINARY = 0x83
+    };
+
+    enum ArkosMsgType : uint8_t {
+        SENSOR_REPORT = 1,
+        BINARY_PAYLOAD = 2,
+        CONTROL_CMD = 3,
+        OTA_TRIGGER = 4
+    };
+
+    ArkosMessageModule();
+
+    virtual bool wantPacket(const meshtastic_MeshPacket *p) override;
+    virtual ProcessMessage handleReceived(const meshtastic_MeshPacket &p) override;
+
+  private:
+    void handleSensorReport(const uint8_t *data, size_t len);
+    void handleBinaryPayload(const uint8_t *data, size_t len);
+    void handleControlCmd(const uint8_t *data, size_t len);
+};

--- a/src/modules/Modules.cpp
+++ b/src/modules/Modules.cpp
@@ -28,6 +28,8 @@
 #if !MESHTASTIC_EXCLUDE_DETECTIONSENSOR
 #include "modules/DetectionSensorModule.h"
 #endif
+#include "NetworkMode.h"
+#include "arkos/ArkosModules.h"
 #if !MESHTASTIC_EXCLUDE_NEIGHBORINFO
 #include "modules/NeighborInfoModule.h"
 #endif
@@ -272,4 +274,8 @@ void setupModules()
     // NOTE! This module must be added LAST because it likes to check for replies from other modules and avoid sending extra
     // acks
     routingModule = new RoutingModule();
+
+    if (currentNetworkMode == NetworkMode::ARKOS) {
+        setupArkosModules();
+    }
 }


### PR DESCRIPTION
## Summary
- implement ArkosRouter with next-hop selection, retry logic and silent forwarding
- implement ArkosMessageModule to parse sensor reports, control commands and OTA triggers
- add ArkosConfig for runtime topology and power options with file-based loading
- store incoming binary payload to flash
- document ArkosMesh architecture and options

## Testing
- ❌ `pio --version` (failed to run: `bash: pio: command not found`)


------
https://chatgpt.com/codex/tasks/task_e_685d8b976e388327b35ebd51c8a3bc28