### PR TITLE
Add modular design doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Meshtastic enables text messaging, location sharing, and telemetry over a decent
 
 - 🔧 **[Building Instructions](https://meshtastic.org/docs/development/firmware/build)** – Learn how to compile the firmware from source.
 - ⚡ **[Flashing Instructions](https://meshtastic.org/docs/getting-started/flashing-firmware/)** – Install or update the firmware on your device.
+- 📚 **[Arkos Modular Design](docs/arkos_modular_design.md)** – covers dual-mode networking and proprietary module guidelines.
 
 Join our community and help improve Meshtastic! 🚀
 


### PR DESCRIPTION
## Summary
- link to Arkos modular design document in README

## Testing
- `platformio test -e coverage -v --junit-output-path testreport.xml` *(fails: platformio not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686840c8ff9483279792e00d67535986